### PR TITLE
Render figure tables using HTML table elements

### DIFF
--- a/gnucash_ixbrl/basicelement.py
+++ b/gnucash_ixbrl/basicelement.py
@@ -108,9 +108,10 @@ h2 {
 
 .table {
   display: table;
-  padding-top: 1rem;
+  table-layout: fixed;  
   border-spacing: 0.3rem 0.1rem;
   border-collapse: separate;
+  width: 100%;
 }
 
 .row {

--- a/gnucash_ixbrl/basicelement.py
+++ b/gnucash_ixbrl/basicelement.py
@@ -103,8 +103,14 @@ h2 {
 }
 
 .sheet {
-  display: table;
   padding: 1rem;
+}
+
+.table {
+  display: table;
+  padding-top: 1rem;
+  border-spacing: 0.3rem 0.1rem;
+  border-collapse: separate;
 }
 
 .row {
@@ -116,10 +122,12 @@ h2 {
   margin-top: 1rem;
 }
 
-.label {
+.cell {
   display: table-cell;
-//  clear: left;
-//  float: left;
+}
+
+.label {
+//  border: 1px solid black;
   width: 20rem;
 }
 
@@ -128,7 +136,7 @@ h2 {
 }
 
 .value {
-  display: table-cell;
+//  border: 1px solid black;
   font-family: Source Code Pro, monospace;
   font-size: 10pt;
 //  float: left;
@@ -173,7 +181,7 @@ h2 {
 }
 
 .periodname {
-  display: table-cell;
+//  border: 1px solid black;
   padding: 0.5em 1em 0.5em 1em;
   border-bottom: 0.2em solid black;
   font-weight: bold;
@@ -184,7 +192,7 @@ h2 {
 }
 
 .currency {
-  display: table-cell;
+//  border: 1px solid black;
   text-align: right;
   padding-left: 1em;
   padding-right: 1em;

--- a/gnucash_ixbrl/basicelement.py
+++ b/gnucash_ixbrl/basicelement.py
@@ -128,7 +128,6 @@ h2 {
 }
 
 .label {
-//  border: 1px solid black;
   width: 20rem;
 }
 
@@ -137,10 +136,8 @@ h2 {
 }
 
 .value {
-//  border: 1px solid black;
   font-family: Source Code Pro, monospace;
   font-size: 10pt;
-//  float: left;
   width: 10rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -182,22 +179,18 @@ h2 {
 }
 
 .periodname {
-//  border: 1px solid black;
   padding: 0.5em 1em 0.5em 1em;
   border-bottom: 0.2em solid black;
   font-weight: bold;
   text-align: center;
-//  float: left;
   width: 10rem;
   margin-right: 1rem;
 }
 
 .currency {
-//  border: 1px solid black;
   text-align: right;
   padding-left: 1em;
   padding-right: 1em;
-//  float: left;
   width: 10rem;
   margin-right: 1rem;
   margin-top: 0.25em;
@@ -210,8 +203,6 @@ h2 {
 .period.value.negative {
   padding-left: 2rem;
   padding-right: 0rem;
-//  position: relative;
-//  left: 1rem;
   color: #400000;
 }
 

--- a/gnucash_ixbrl/basicelement.py
+++ b/gnucash_ixbrl/basicelement.py
@@ -103,7 +103,12 @@ h2 {
 }
 
 .sheet {
+  display: table;
   padding: 1rem;
+}
+
+.row {
+  display: table-row;
 }
 
 .header {
@@ -112,8 +117,9 @@ h2 {
 }
 
 .label {
-  clear: left;
-  float: left;
+  display: table-cell;
+//  clear: left;
+//  float: left;
   width: 20rem;
 }
 
@@ -122,9 +128,10 @@ h2 {
 }
 
 .value {
+  display: table-cell;
   font-family: Source Code Pro, monospace;
   font-size: 10pt;
-  float: left;
+//  float: left;
   width: 10rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -166,20 +173,22 @@ h2 {
 }
 
 .periodname {
+  display: table-cell;
   padding: 0.5em 1em 0.5em 1em;
   border-bottom: 0.2em solid black;
   font-weight: bold;
   text-align: center;
-  float: left;
+//  float: left;
   width: 10rem;
   margin-right: 1rem;
 }
 
 .currency {
+  display: table-cell;
   text-align: right;
   padding-left: 1em;
   padding-right: 1em;
-  float: left;
+//  float: left;
   width: 10rem;
   margin-right: 1rem;
   margin-top: 0.25em;

--- a/gnucash_ixbrl/basicelement.py
+++ b/gnucash_ixbrl/basicelement.py
@@ -109,7 +109,7 @@ h2 {
 .table {
   display: table;
   table-layout: fixed;  
-  border-spacing: 0.3rem 0.1rem;
+  border-spacing: 0.3rem 0rem;
   border-collapse: separate;
   width: 100%;
 }
@@ -151,7 +151,7 @@ h2 {
     width: 18%;
   }
   * {
-    font-size: 1rem;
+    font-size: 1.1rem;
   }
   .label {
     width: 40%; 

--- a/gnucash_ixbrl/ixbrl.py
+++ b/gnucash_ixbrl/ixbrl.py
@@ -14,37 +14,45 @@ class IxbrlReporter:
 
         return self.create_report(worksheet)
 
-    def add_header(self, grid, periods):
+    def add_header(self, table, periods):
 
-        line = self.par.xhtml_maker.div({"class": "row"})
-        grid.append(line)
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
         # Blank header cell
         blank = self.par.xhtml_maker.div("\u00a0")
-        blank.set("class", "label")
-        line.append(blank)
+        blank.set("class", "label cell")
+        row.append(blank)
 
         # Header cells for period names
         for period in periods:
 
             elt = self.par.xhtml_maker.div(period.name)
-            line.append(elt)
-            elt.set("class", "period periodname")
+            row.append(elt)
+            elt.set("class", "period periodname cell")
 
-        line = self.par.xhtml_maker.div({"class": "row"})
-        grid.append(line)
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
         # Blank header cell
         blank = self.par.xhtml_maker.div("\u00a0")
-        blank.set("class", "label")
-        line.append(blank)
+        blank.set("class", "label cell")
+        row.append(blank)
 
         # Header cells for currencies
         for period in periods:
 
             elt = self.par.xhtml_maker.div("£")
-            line.append(elt)
-            elt.set("class", "period currency")
+            row.append(elt)
+            elt.set("class", "period currency cell")
+
+        # Empty row
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
+
+        blank = self.par.xhtml_maker.div("\u00a0")
+        blank.set("class", "label cell")
+        row.append(blank)
 
     def maybe_tag(self, datum, section, pid):
 
@@ -112,13 +120,13 @@ class IxbrlReporter:
 
         return self.par.xhtml_maker.span("{0:,.2f}".format(val))
 
-    def add_nil_section(self, grid, section, periods):
+    def add_nil_section(self, table, section, periods):
 
-        line = self.par.xhtml_maker.div({"class": "row"})
-        grid.append(line)
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
         div = self.par.xhtml_maker.div()
-        div.set("class", "label header")
+        div.set("class", "label header cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
             desc = self.taxonomy.create_description_fact(
@@ -128,25 +136,33 @@ class IxbrlReporter:
         else:
             div.append(self.par.xhtml_maker.span(section.header))
 
-        line.append(div)
+        row.append(div)
 
         for i in range(0, len(periods)):
             div = self.par.xhtml_maker.div()
             div.set(
                 "class",
-                "period total value nil rank%d" % section.total.rank
+                "period total value nil rank%d cell" % section.total.rank
             )
-            line.append(div)
+            row.append(div)
             content = self.maybe_tag(0, section, i)
             div.append(content)
 
-    def add_total_section(self, grid, section, periods):
+        # Empty row
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
-        line = self.par.xhtml_maker.div({"class": "row"})
-        grid.append(line)
+        blank = self.par.xhtml_maker.div("\u00a0")
+        blank.set("class", "label cell")
+        row.append(blank)
+
+    def add_total_section(self, table, section, periods):
+
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
         div = self.par.xhtml_maker.div()
-        div.set("class", "label header total")
+        div.set("class", "label header total cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
             desc = self.taxonomy.create_description_fact(
@@ -156,37 +172,45 @@ class IxbrlReporter:
         else:
             div.append(self.par.xhtml_maker.span(section.header))
 
-        line.append(div)
+        row.append(div)
 
         for i in range(0, len(periods)):
             div = self.par.xhtml_maker.div()
-            line.append(div)
+            row.append(div)
             value = section.total.values[i]
             if abs(value.value) < 0.001:
                 div.set(
                     "class",
-                    "period total value nil rank%d" % section.total.rank
+                    "period total value nil rank%d cell" % section.total.rank
                 )
             elif value.value < 0:
                 div.set(
                     "class",
-                    "period total value negative rank%d" % section.total.rank
+                    "period total value negative rank%d cell" % section.total.rank
                 )
             else:
                 div.set(
                     "class",
-                    "period total value rank%d" % section.total.rank
+                    "period total value rank%d cell" % section.total.rank
                 )
             content = self.maybe_tag(value, section, i)
             div.append(content)
 
-    def add_breakdown_section(self, grid, section, periods):
+        # Empty row
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
-        line = self.par.xhtml_maker.div({"class": "row"})
-        grid.append(line)
+        blank = self.par.xhtml_maker.div("\u00a0")
+        blank.set("class", "label cell")
+        row.append(blank)
+
+    def add_breakdown_section(self, table, section, periods):
+
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
         div = self.par.xhtml_maker.div()
-        div.set("class", "label breakdown header")
+        div.set("class", "label breakdown header cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
             desc = self.taxonomy.create_description_fact(
@@ -195,15 +219,15 @@ class IxbrlReporter:
             div.append(desc.to_elt(self.par))
         else:
             div.append(self.par.xhtml_maker.span(section.header))
-        line.append(div)
+        row.append(div)
 
         for item in section.items:
 
-            line = self.par.xhtml_maker.div({"class": "row"})
-            grid.append(line)
+            row = self.par.xhtml_maker.div({"class": "row"})
+            table.append(row)
 
             div = self.par.xhtml_maker.div()
-            div.set("class", "label breakdown item")
+            div.set("class", "label breakdown item cell")
 
             if len(item.values) > 0 and item.values[0].id:
                 desc = self.taxonomy.create_description_fact(
@@ -213,7 +237,7 @@ class IxbrlReporter:
             else:
                 div.append(self.par.xhtml_maker.span(item.description))
 
-            line.append(div)
+            row.append(div)
 
             for i in range(0, len(periods)):
 
@@ -222,46 +246,55 @@ class IxbrlReporter:
                 div = self.par.xhtml_maker.div()
                 if abs(value.value) < 0.001:
                     div.set("class",
-                                     "period value nil rank%d" % item.rank )
+                            "period value nil rank%d cell" % item.rank )
                 elif value.value < 0:
                     div.set("class",
-                                     "period value negative rank%d" % item.rank)
+                            "period value negative rank%d cell" % item.rank)
                 else:
                     div.set("class",
-                                     "period value rank%d" % item.rank)
+                            "period value rank%d cell" % item.rank)
 
                 content = self.maybe_tag(value, item, i)
 
                 div.append(content)
-                line.append(div)
+                row.append(div)
 
-        line = self.par.xhtml_maker.div({"class": "row"})
-        grid.append(line)
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
 
         div = self.par.xhtml_maker.div()
-        div.set("class", "label breakdown total")
-        line.append(div)
+        div.set("class", "label breakdown total cell")
+        row.append(div)
         div.append(self.par.xhtml_maker.span("Total"))
 
         for i in range(0, len(periods)):
 
             div = self.par.xhtml_maker.div()
 
-            line.append(div)
+            row.append(div)
 
             value = section.total.values[i]
 
             if abs(value.value) < 0.001:
                 div.set("class",
-                                 "period value nil breakdown total rank%d" % section.total.rank)
+                        "period value nil breakdown total rank%d cell" % section.total.rank)
             elif value.value < 0:
                 div.set("class",
-                                 "period value negative breakdown total rank%d" % section.total.rank)
+                        "period value negative breakdown total rank%d cell" % section.total.rank)
             else:
-                div.set("class", "period value breakdown total rank%d" % section.total.rank)
+                div.set("class",
+                        "period value breakdown total rank%d cell" % section.total.rank)
 
             content = self.maybe_tag(value, section, i)
             div.append(content)
+
+        # Empty row
+        row = self.par.xhtml_maker.div({"class": "row"})
+        table.append(row)
+
+        blank = self.par.xhtml_maker.div("\u00a0")
+        blank.set("class", "label cell")
+        row.append(blank)
 
     def add_section(self, grid, section, periods):
 
@@ -284,7 +317,7 @@ class IxbrlReporter:
         sections = ds.sections
 
         grid = self.par.xhtml_maker.div()
-        grid.set("class", "sheet")
+        grid.set("class", "sheet table")
 
         self.add_header(grid, periods)
 

--- a/gnucash_ixbrl/ixbrl.py
+++ b/gnucash_ixbrl/ixbrl.py
@@ -16,28 +16,34 @@ class IxbrlReporter:
 
     def add_header(self, grid, periods):
 
+        line = self.par.xhtml_maker.div({"class": "row"})
+        grid.append(line)
+
         # Blank header cell
         blank = self.par.xhtml_maker.div("\u00a0")
         blank.set("class", "label")
-        grid.append(blank)
+        line.append(blank)
 
         # Header cells for period names
         for period in periods:
 
             elt = self.par.xhtml_maker.div(period.name)
-            grid.append(elt)
+            line.append(elt)
             elt.set("class", "period periodname")
+
+        line = self.par.xhtml_maker.div({"class": "row"})
+        grid.append(line)
 
         # Blank header cell
         blank = self.par.xhtml_maker.div("\u00a0")
         blank.set("class", "label")
-        grid.append(blank)
+        line.append(blank)
 
-        # Header cells for period names
+        # Header cells for currencies
         for period in periods:
 
             elt = self.par.xhtml_maker.div("£")
-            grid.append(elt)
+            line.append(elt)
             elt.set("class", "period currency")
 
     def maybe_tag(self, datum, section, pid):
@@ -108,6 +114,9 @@ class IxbrlReporter:
 
     def add_nil_section(self, grid, section, periods):
 
+        line = self.par.xhtml_maker.div({"class": "row"})
+        grid.append(line)
+
         div = self.par.xhtml_maker.div()
         div.set("class", "label header")
 
@@ -119,7 +128,7 @@ class IxbrlReporter:
         else:
             div.append(self.par.xhtml_maker.span(section.header))
 
-        grid.append(div)
+        line.append(div)
 
         for i in range(0, len(periods)):
             div = self.par.xhtml_maker.div()
@@ -127,11 +136,14 @@ class IxbrlReporter:
                 "class",
                 "period total value nil rank%d" % section.total.rank
             )
-            grid.append(div)
+            line.append(div)
             content = self.maybe_tag(0, section, i)
             div.append(content)
 
     def add_total_section(self, grid, section, periods):
+
+        line = self.par.xhtml_maker.div({"class": "row"})
+        grid.append(line)
 
         div = self.par.xhtml_maker.div()
         div.set("class", "label header total")
@@ -144,11 +156,11 @@ class IxbrlReporter:
         else:
             div.append(self.par.xhtml_maker.span(section.header))
 
-        grid.append(div)
+        line.append(div)
 
         for i in range(0, len(periods)):
             div = self.par.xhtml_maker.div()
-            grid.append(div)
+            line.append(div)
             value = section.total.values[i]
             if abs(value.value) < 0.001:
                 div.set(
@@ -170,6 +182,9 @@ class IxbrlReporter:
 
     def add_breakdown_section(self, grid, section, periods):
 
+        line = self.par.xhtml_maker.div({"class": "row"})
+        grid.append(line)
+
         div = self.par.xhtml_maker.div()
         div.set("class", "label breakdown header")
 
@@ -180,9 +195,12 @@ class IxbrlReporter:
             div.append(desc.to_elt(self.par))
         else:
             div.append(self.par.xhtml_maker.span(section.header))
-        grid.append(div)
+        line.append(div)
 
         for item in section.items:
+
+            line = self.par.xhtml_maker.div({"class": "row"})
+            grid.append(line)
 
             div = self.par.xhtml_maker.div()
             div.set("class", "label breakdown item")
@@ -195,7 +213,7 @@ class IxbrlReporter:
             else:
                 div.append(self.par.xhtml_maker.span(item.description))
 
-            grid.append(div)
+            line.append(div)
 
             for i in range(0, len(periods)):
 
@@ -215,18 +233,21 @@ class IxbrlReporter:
                 content = self.maybe_tag(value, item, i)
 
                 div.append(content)
-                grid.append(div)
+                line.append(div)
+
+        line = self.par.xhtml_maker.div({"class": "row"})
+        grid.append(line)
 
         div = self.par.xhtml_maker.div()
         div.set("class", "label breakdown total")
-        grid.append(div)
+        line.append(div)
         div.append(self.par.xhtml_maker.span("Total"))
 
         for i in range(0, len(periods)):
 
             div = self.par.xhtml_maker.div()
 
-            grid.append(div)
+            line.append(div)
 
             value = section.total.values[i]
 

--- a/gnucash_ixbrl/ixbrl.py
+++ b/gnucash_ixbrl/ixbrl.py
@@ -7,13 +7,25 @@ from lxml import objectify
 
 class IxbrlReporter:
 
+    def add_empty_row(self, table):
+
+        row = self.par.xhtml_maker.tr({"class": "row"})
+        table.append(row)
+
+        blank = self.create_cell("\u00a0")
+        blank.set("class", "label cell")
+        row.append(blank)
+
     def create_table(self):
         grid = self.par.xhtml_maker.table()
         grid.set("class", "sheet table")
         return grid
 
-    def create_row(self):
-        return self.par.xhtml_maker.tr({"class": "row"})
+    def add_row(self, table, elts):
+        row = self.par.xhtml_maker.tr({"class": "row"})
+        for elt in elts:
+            row.append(elt)
+        table.append(row)
 
     def create_cell(self, text=None):
         if text == None:
@@ -30,8 +42,7 @@ class IxbrlReporter:
 
     def add_header(self, table, periods):
 
-        row = self.create_row()
-        table.append(row)
+        row = []
 
         # Blank header cell
         blank = self.create_cell("\u00a0")
@@ -45,8 +56,9 @@ class IxbrlReporter:
             row.append(elt)
             elt.set("class", "period periodname cell")
 
-        row = self.create_row()
-        table.append(row)
+        self.add_row(table, row)
+
+        row = []
 
         # Blank header cell
         blank = self.create_cell("\u00a0")
@@ -60,13 +72,10 @@ class IxbrlReporter:
             row.append(elt)
             elt.set("class", "period currency cell")
 
-        # Empty row
-        row = self.create_row()
-        table.append(row)
+        self.add_row(table, row)
 
-        blank = self.create_cell("\u00a0")
-        blank.set("class", "label cell")
-        row.append(blank)
+        # Empty row
+        self.add_empty_row(table)
 
     def maybe_tag(self, datum, section, pid):
 
@@ -136,8 +145,7 @@ class IxbrlReporter:
 
     def add_nil_section(self, table, section, periods):
 
-        row = self.create_row()
-        table.append(row)
+        row = []
 
         div = self.create_cell()
         div.set("class", "label header cell")
@@ -162,18 +170,14 @@ class IxbrlReporter:
             content = self.maybe_tag(0, section, i)
             div.append(content)
 
-        # Empty row
-        row = self.create_row()
-        table.append(row)
+        self.add_row(table, row)
 
-        blank = self.create_cell("\u00a0")
-        blank.set("class", "label cell")
-        row.append(blank)
+        # Empty row
+        self.add_empty_row(table)
 
     def add_total_section(self, table, section, periods):
 
-        row = self.create_row()
-        table.append(row)
+        row = []
 
         div = self.create_cell()
         div.set("class", "label header total cell")
@@ -210,18 +214,14 @@ class IxbrlReporter:
             content = self.maybe_tag(value, section, i)
             div.append(content)
 
-        # Empty row
-        row = self.create_row()
-        table.append(row)
+        self.add_row(table, row)
 
-        blank = self.create_cell("\u00a0")
-        blank.set("class", "label cell")
-        row.append(blank)
+        # Empty row
+        self.add_empty_row(table)
 
     def add_breakdown_section(self, table, section, periods):
 
-        row = self.create_row()
-        table.append(row)
+        row = []
 
         div = self.create_cell()
         div.set("class", "label breakdown header cell")
@@ -235,10 +235,11 @@ class IxbrlReporter:
             div.append(self.par.xhtml_maker.span(section.header))
         row.append(div)
 
+        self.add_row(table, row)
+
         for item in section.items:
 
-            row = self.create_row()
-            table.append(row)
+            row = []
 
             div = self.create_cell()
             div.set("class", "label breakdown item cell")
@@ -273,8 +274,9 @@ class IxbrlReporter:
                 div.append(content)
                 row.append(div)
 
-        row = self.create_row()
-        table.append(row)
+            self.add_row(table, row)
+
+        row = []
 
         div = self.create_cell()
         div.set("class", "label breakdown total cell")
@@ -302,13 +304,10 @@ class IxbrlReporter:
             content = self.maybe_tag(value, section, i)
             div.append(content)
 
-        # Empty row
-        row = self.create_row()
-        table.append(row)
+        self.add_row(table, row)
 
-        blank = self.create_cell("\u00a0")
-        blank.set("class", "label cell")
-        row.append(blank)
+        # Empty row
+        self.add_empty_row(table)
 
     def add_section(self, grid, section, periods):
 

--- a/gnucash_ixbrl/ixbrl.py
+++ b/gnucash_ixbrl/ixbrl.py
@@ -7,6 +7,20 @@ from lxml import objectify
 
 class IxbrlReporter:
 
+    def create_table(self):
+        grid = self.par.xhtml_maker.table()
+        grid.set("class", "sheet table")
+        return grid
+
+    def create_row(self):
+        return self.par.xhtml_maker.tr({"class": "row"})
+
+    def create_cell(self, text=None):
+        if text == None:
+            return self.par.xhtml_maker.td()
+        else:
+            return self.par.xhtml_maker.td(text)
+
     def get_elt(self, worksheet, par, taxonomy):
 
         self.par = par
@@ -16,41 +30,41 @@ class IxbrlReporter:
 
     def add_header(self, table, periods):
 
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
         # Blank header cell
-        blank = self.par.xhtml_maker.td("\u00a0")
+        blank = self.create_cell("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
         # Header cells for period names
         for period in periods:
 
-            elt = self.par.xhtml_maker.td(period.name)
+            elt = self.create_cell(period.name)
             row.append(elt)
             elt.set("class", "period periodname cell")
 
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
         # Blank header cell
-        blank = self.par.xhtml_maker.td("\u00a0")
+        blank = self.create_cell("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
         # Header cells for currencies
         for period in periods:
 
-            elt = self.par.xhtml_maker.td("£")
+            elt = self.create_cell("£")
             row.append(elt)
             elt.set("class", "period currency cell")
 
         # Empty row
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        blank = self.par.xhtml_maker.td("\u00a0")
+        blank = self.create_cell("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
@@ -122,10 +136,10 @@ class IxbrlReporter:
 
     def add_nil_section(self, table, section, periods):
 
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        div = self.par.xhtml_maker.td()
+        div = self.create_cell()
         div.set("class", "label header cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
@@ -139,7 +153,7 @@ class IxbrlReporter:
         row.append(div)
 
         for i in range(0, len(periods)):
-            div = self.par.xhtml_maker.td()
+            div = self.create_cell()
             div.set(
                 "class",
                 "period total value nil rank%d cell" % section.total.rank
@@ -149,19 +163,19 @@ class IxbrlReporter:
             div.append(content)
 
         # Empty row
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        blank = self.par.xhtml_maker.td("\u00a0")
+        blank = self.create_cell("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
     def add_total_section(self, table, section, periods):
 
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        div = self.par.xhtml_maker.td()
+        div = self.create_cell()
         div.set("class", "label header total cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
@@ -175,7 +189,7 @@ class IxbrlReporter:
         row.append(div)
 
         for i in range(0, len(periods)):
-            div = self.par.xhtml_maker.td()
+            div = self.create_cell()
             row.append(div)
             value = section.total.values[i]
             if abs(value.value) < 0.001:
@@ -197,19 +211,19 @@ class IxbrlReporter:
             div.append(content)
 
         # Empty row
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        blank = self.par.xhtml_maker.td("\u00a0")
+        blank = self.create_cell("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
     def add_breakdown_section(self, table, section, periods):
 
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        div = self.par.xhtml_maker.td()
+        div = self.create_cell()
         div.set("class", "label breakdown header cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
@@ -223,10 +237,10 @@ class IxbrlReporter:
 
         for item in section.items:
 
-            row = self.par.xhtml_maker.tr({"class": "row"})
+            row = self.create_row()
             table.append(row)
 
-            div = self.par.xhtml_maker.td()
+            div = self.create_cell()
             div.set("class", "label breakdown item cell")
 
             if len(item.values) > 0 and item.values[0].id:
@@ -243,7 +257,7 @@ class IxbrlReporter:
 
                 value = item.values[i]
 
-                div = self.par.xhtml_maker.td()
+                div = self.create_cell()
                 if abs(value.value) < 0.001:
                     div.set("class",
                             "period value nil rank%d cell" % item.rank )
@@ -259,17 +273,17 @@ class IxbrlReporter:
                 div.append(content)
                 row.append(div)
 
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        div = self.par.xhtml_maker.td()
+        div = self.create_cell()
         div.set("class", "label breakdown total cell")
         row.append(div)
         div.append(self.par.xhtml_maker.span("Total"))
 
         for i in range(0, len(periods)):
 
-            div = self.par.xhtml_maker.td()
+            div = self.create_cell()
 
             row.append(div)
 
@@ -289,10 +303,10 @@ class IxbrlReporter:
             div.append(content)
 
         # Empty row
-        row = self.par.xhtml_maker.tr({"class": "row"})
+        row = self.create_row()
         table.append(row)
 
-        blank = self.par.xhtml_maker.td("\u00a0")
+        blank = self.create_cell("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
@@ -316,8 +330,7 @@ class IxbrlReporter:
         periods = ds.periods
         sections = ds.sections
 
-        grid = self.par.xhtml_maker.table()
-        grid.set("class", "sheet table")
+        grid = self.create_table()
 
         self.add_header(grid, periods)
 

--- a/gnucash_ixbrl/ixbrl.py
+++ b/gnucash_ixbrl/ixbrl.py
@@ -16,41 +16,41 @@ class IxbrlReporter:
 
     def add_header(self, table, periods):
 
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
         # Blank header cell
-        blank = self.par.xhtml_maker.div("\u00a0")
+        blank = self.par.xhtml_maker.td("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
         # Header cells for period names
         for period in periods:
 
-            elt = self.par.xhtml_maker.div(period.name)
+            elt = self.par.xhtml_maker.td(period.name)
             row.append(elt)
             elt.set("class", "period periodname cell")
 
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
         # Blank header cell
-        blank = self.par.xhtml_maker.div("\u00a0")
+        blank = self.par.xhtml_maker.td("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
         # Header cells for currencies
         for period in periods:
 
-            elt = self.par.xhtml_maker.div("£")
+            elt = self.par.xhtml_maker.td("£")
             row.append(elt)
             elt.set("class", "period currency cell")
 
         # Empty row
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        blank = self.par.xhtml_maker.div("\u00a0")
+        blank = self.par.xhtml_maker.td("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
@@ -122,10 +122,10 @@ class IxbrlReporter:
 
     def add_nil_section(self, table, section, periods):
 
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        div = self.par.xhtml_maker.div()
+        div = self.par.xhtml_maker.td()
         div.set("class", "label header cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
@@ -139,7 +139,7 @@ class IxbrlReporter:
         row.append(div)
 
         for i in range(0, len(periods)):
-            div = self.par.xhtml_maker.div()
+            div = self.par.xhtml_maker.td()
             div.set(
                 "class",
                 "period total value nil rank%d cell" % section.total.rank
@@ -149,19 +149,19 @@ class IxbrlReporter:
             div.append(content)
 
         # Empty row
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        blank = self.par.xhtml_maker.div("\u00a0")
+        blank = self.par.xhtml_maker.td("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
     def add_total_section(self, table, section, periods):
 
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        div = self.par.xhtml_maker.div()
+        div = self.par.xhtml_maker.td()
         div.set("class", "label header total cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
@@ -175,7 +175,7 @@ class IxbrlReporter:
         row.append(div)
 
         for i in range(0, len(periods)):
-            div = self.par.xhtml_maker.div()
+            div = self.par.xhtml_maker.td()
             row.append(div)
             value = section.total.values[i]
             if abs(value.value) < 0.001:
@@ -197,19 +197,19 @@ class IxbrlReporter:
             div.append(content)
 
         # Empty row
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        blank = self.par.xhtml_maker.div("\u00a0")
+        blank = self.par.xhtml_maker.td("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
     def add_breakdown_section(self, table, section, periods):
 
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        div = self.par.xhtml_maker.div()
+        div = self.par.xhtml_maker.td()
         div.set("class", "label breakdown header cell")
 
         if len(section.total.values) > 0 and section.total.values[0].id:
@@ -223,10 +223,10 @@ class IxbrlReporter:
 
         for item in section.items:
 
-            row = self.par.xhtml_maker.div({"class": "row"})
+            row = self.par.xhtml_maker.tr({"class": "row"})
             table.append(row)
 
-            div = self.par.xhtml_maker.div()
+            div = self.par.xhtml_maker.td()
             div.set("class", "label breakdown item cell")
 
             if len(item.values) > 0 and item.values[0].id:
@@ -243,7 +243,7 @@ class IxbrlReporter:
 
                 value = item.values[i]
 
-                div = self.par.xhtml_maker.div()
+                div = self.par.xhtml_maker.td()
                 if abs(value.value) < 0.001:
                     div.set("class",
                             "period value nil rank%d cell" % item.rank )
@@ -259,17 +259,17 @@ class IxbrlReporter:
                 div.append(content)
                 row.append(div)
 
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        div = self.par.xhtml_maker.div()
+        div = self.par.xhtml_maker.td()
         div.set("class", "label breakdown total cell")
         row.append(div)
         div.append(self.par.xhtml_maker.span("Total"))
 
         for i in range(0, len(periods)):
 
-            div = self.par.xhtml_maker.div()
+            div = self.par.xhtml_maker.td()
 
             row.append(div)
 
@@ -289,10 +289,10 @@ class IxbrlReporter:
             div.append(content)
 
         # Empty row
-        row = self.par.xhtml_maker.div({"class": "row"})
+        row = self.par.xhtml_maker.tr({"class": "row"})
         table.append(row)
 
-        blank = self.par.xhtml_maker.div("\u00a0")
+        blank = self.par.xhtml_maker.td("\u00a0")
         blank.set("class", "label cell")
         row.append(blank)
 
@@ -316,7 +316,7 @@ class IxbrlReporter:
         periods = ds.periods
         sections = ds.sections
 
-        grid = self.par.xhtml_maker.div()
+        grid = self.par.xhtml_maker.table()
         grid.set("class", "sheet table")
 
         self.add_header(grid, periods)


### PR DESCRIPTION
Render figure tables using HTML table elements instead of div elements with float / clear CSS. This appears to produce more uniformly formatted output. I've been testing with browser print, `wkhtmltopdf` and the Companies House image formatter.